### PR TITLE
aprs-to-discord: speed in MPH (km/h in parens)

### DIFF
--- a/aws/lambda/aprs-to-discord/lambda_function.py
+++ b/aws/lambda/aprs-to-discord/lambda_function.py
@@ -100,7 +100,8 @@ def _format_message(active, now):
         except (TypeError, ValueError):
             speed = 0.0
         if speed > 0:
-            lines.append(f"\U0001F697 **Speed:** {speed:.0f} km/h")
+            mph = round(speed * 0.621371)
+            lines.append(f"\U0001F697 **Speed:** {mph}MPH ({round(speed)} km/h)")
         comment = (entry.get("comment") or "").strip()
         if comment:
             lines.append(f"\U0001F4AC **Comment:** {comment}")


### PR DESCRIPTION
## Summary
Show APRS station speed in **MPH** (lead) with km/h kept in parentheses, no decimals — per request:

`🚗 **Speed:** 76MPH (123 km/h)`

Converts the aprs.fi km/h value (`mph = round(km/h × 0.621371)`), both values rounded to whole numbers. Only shown when the station is moving. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
