### PR TITLE
aprs-to-discord: callsign wildcard (trailing *) support

### DIFF
--- a/aws/lambda/aprs-to-discord/callsigns.txt
+++ b/aws/lambda/aprs-to-discord/callsigns.txt
@@ -1,5 +1,7 @@
 # APRS watch list for aprs-to-discord.
 # One callsign per line (SSIDs allowed, e.g. W6XYZ-9).
+# A trailing '*' matches all SSIDs of a base call (e.g. WZ1EEE* covers
+# WZ1EEE and WZ1EEE-1 through WZ1EEE-15).
 # Lines starting with '#' and blank lines are ignored.
 # Add the callsigns you want to monitor below:
 WZ1EEE*

--- a/aws/lambda/aprs-to-discord/lambda_function.py
+++ b/aws/lambda/aprs-to-discord/lambda_function.py
@@ -34,8 +34,24 @@ USER_AGENT = "evsrt-aprs-to-discord/1.0 (+https://evsrt.org)"
 APRS_MAX_TARGETS = 20
 
 
+def _expand_callsign(token):
+    """Expand a watch-list token into concrete aprs.fi targets.
+
+    aprs.fi matches exact identifiers (no wildcards), so a trailing '*'
+    is expanded here: "BASE*" (or "BASE-*") means the base call on any
+    SSID, i.e. the bare base (SSID 0) plus BASE-1 .. BASE-15.
+    """
+    if token.endswith("*"):
+        base = token[:-1].rstrip("-")
+        if not base:
+            return []
+        return [base] + [f"{base}-{i}" for i in range(1, 16)]
+    return [token]
+
+
 def _load_callsigns():
-    """Watch list from callsigns.txt -- one per line, '#' comments ignored."""
+    """Watch list from callsigns.txt -- one per line, '#' comments ignored.
+    Trailing-'*' wildcards are expanded to every SSID (see _expand_callsign)."""
     path = Path(__file__).parent / "callsigns.txt"
     if not path.exists():
         print("callsigns.txt not found next to lambda_function.py")
@@ -45,9 +61,10 @@ def _load_callsigns():
         cs = line.strip().upper()
         if not cs or cs.startswith("#"):
             continue
-        if cs not in seen:
-            seen.add(cs)
-            out.append(cs)
+        for target in _expand_callsign(cs):
+            if target not in seen:
+                seen.add(target)
+                out.append(target)
     return out
 
 


### PR DESCRIPTION
## Summary
Adds trailing-`*` wildcard support to the `aprs-to-discord` watch list.

**Why:** aprs.fi's `what=loc` API matches *exact* identifiers — no wildcards — so `WZ1EEE*` was being sent literally and matching nothing. This expands wildcards client-side before querying.

**Behavior:** a trailing `*` (e.g. `WZ1EEE*` or `WZ1EEE-*`) means "this base call on any SSID" and expands to the bare base (SSID 0) plus `-1` … `-15` — 16 targets. So `WZ1EEE*` now catches `WZ1EEE`, `WZ1EEE-9`, etc. Plain entries (`KI6CR-9`) are unchanged. The existing 20-targets-per-query batching handles the larger list.

Documented the syntax in `callsigns.txt`. `py_compile` clean; expansion spot-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
