### PR TITLE
discord-spot-bot: blockquote each spot for visual separation

### DIFF
--- a/aws/lambda/discord-spot-bot/lambda_function.py
+++ b/aws/lambda/discord-spot-bot/lambda_function.py
@@ -24,14 +24,18 @@ def lambda_handler(event, context):
     discord_webhook = os.environ.get('discord_webhook')
     mattermost_webhook = os.environ.get('mattermost_webhook')
 
-    # Format Discord message
+    # Format Discord message. Every line is prefixed with "> " so Discord
+    # renders the whole spot as one blockquote -- a left-border bar that
+    # visually boxes each alert and keeps back-to-back spots from running
+    # together in the channel.
     discord_message = {
-        "content": f"📡 **New {source.upper()} Spot Alert!**\n\n"
-                   f"📌 **Callsign:** {full_callsign}\n"
-                   f"🔊 **Frequency:** {frequency} MHz ({band})\n"
-                   f"🎛️ **Mode:** {mode.upper()} ({mode_detail.upper()})\n"
-                   f"👤 **Spotter:** {spotter}\n"
-                   f"💬 **Comment:** {comment}\n",
+        "content": f"> 📡 **New {source.upper()} Spot Alert!**\n"
+                   f"> \n"
+                   f"> 📌 **Callsign:** {full_callsign}\n"
+                   f"> 🔊 **Frequency:** {frequency} MHz ({band})\n"
+                   f"> 🎛️ **Mode:** {mode.upper()} ({mode_detail.upper()})\n"
+                   f"> 👤 **Spotter:** {spotter}\n"
+                   f"> 💬 **Comment:** {comment}",
         "username": "HamBOT 🐷"
     }
 


### PR DESCRIPTION
## Summary
POTA/SOTA spot alerts were running together in the Discord channel — each spot is its own message, but with no visual boundary they blur into one wall of text.

Now every line of the alert is prefixed with `> `, so Discord renders each spot as a single **blockquote** — a left-border bar that boxes one spot and clearly separates it from the next:

> 📡 **New POTA Spot Alert!**
>
> 📌 **Callsign:** W6XYZ
> 🔊 **Frequency:** 14.285 MHz (20m)
> 🎛️ **Mode:** SSB (PHONE)
> 👤 **Spotter:** K6ABC
> 💬 **Comment:** calling CQ

Discord message only; the Mattermost payload is unchanged. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
