### PR TITLE
aprs-to-discord blockquote + deploy only changed Lambdas (match angeles-intel)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,51 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        # Full history so we can diff this push against its predecessor.
+        fetch-depth: 0
+
+    - name: Detect changed paths
+      id: changes
+      run: |
+        BEFORE="${{ github.event.before }}"
+        ZERO="0000000000000000000000000000000000000000"
+        if [ -z "$BEFORE" ] || [ "$BEFORE" = "$ZERO" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+          # First push, force-push, or unknown base -> deploy everything.
+          echo "Base commit unavailable; deploying all targets."
+          CHANGED="__ALL__"
+        else
+          CHANGED="$(git diff --name-only "$BEFORE" "${{ github.sha }}")"
+        fi
+        echo "Changed files:"
+        echo "$CHANGED"
+
+        changed() {
+          [ "$CHANGED" = "__ALL__" ] && return 0
+          echo "$CHANGED" | grep -q "^$1"
+        }
+
+        site=false;     changed "site/"                            && site=true
+        reminder=false; changed "aws/lambda/discord-reminder-bot/" && reminder=true
+        spot=false;     changed "aws/lambda/discord-spot-bot/"     && spot=true
+        digest=false;   changed "aws/lambda/email-digest/"         && digest=true
+        unsub=false;    changed "aws/lambda/email-unsub/"          && unsub=true
+        aprs=false;     changed "aws/lambda/aprs-to-discord/"      && aprs=true
+
+        any_lambda=false
+        if [ "$reminder" = true ] || [ "$spot" = true ] || [ "$digest" = true ] || [ "$unsub" = true ] || [ "$aprs" = true ]; then
+          any_lambda=true
+        fi
+
+        {
+          echo "site=$site"
+          echo "reminder=$reminder"
+          echo "spot=$spot"
+          echo "digest=$digest"
+          echo "unsub=$unsub"
+          echo "aprs=$aprs"
+          echo "any_lambda=$any_lambda"
+        } >> "$GITHUB_OUTPUT"
 
     - name: Configure AWS CLI SDK
       uses: aws-actions/configure-aws-credentials@v2
@@ -19,6 +64,7 @@ jobs:
         aws-region: us-east-1
 
     - name: Deploy static content to S3
+      if: steps.changes.outputs.site == 'true'
       env:
         AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
       run: |
@@ -32,11 +78,13 @@ jobs:
         aws s3 sync ./site/ s3://${S3_DEST}/ --region us-west-2 --cache-control max-age=120,must-revalidate --delete
 
     - name: Set up Python
+      if: steps.changes.outputs.any_lambda == 'true'
       uses: actions/setup-python@v4
       with:
         python-version: '3.11'
 
     - name: Build Lambda discord-reminder-bot
+      if: steps.changes.outputs.reminder == 'true'
       run: |
         cd ./aws/lambda/discord-reminder-bot/
         python -m pip install --upgrade pip
@@ -46,6 +94,7 @@ jobs:
         cd package && zip -r ../lambda.zip . && cd ..
 
     - name: Upload Lambda discord-reminder-bot
+      if: steps.changes.outputs.reminder == 'true'
       run: |
         cd ./aws/lambda/discord-reminder-bot/
         aws lambda update-function-code \
@@ -54,6 +103,7 @@ jobs:
 
 
     - name: Build Lambda discord-spot-bot
+      if: steps.changes.outputs.spot == 'true'
       run: |
         cd ./aws/lambda/discord-spot-bot/
         python -m pip install --upgrade pip
@@ -63,6 +113,7 @@ jobs:
         cd package && zip -r ../lambda.zip . && cd ..
 
     - name: Upload Lambda discord-spot-bot
+      if: steps.changes.outputs.spot == 'true'
       run: |
         cd ./aws/lambda/discord-spot-bot/
         aws lambda update-function-code \
@@ -71,6 +122,7 @@ jobs:
 
 
     - name: Build Lambda email-digest
+      if: steps.changes.outputs.digest == 'true'
       run: |
         cd ./aws/lambda/email-digest/
         rm -rf package lambda.zip
@@ -81,6 +133,7 @@ jobs:
         cd package && zip -r ../lambda.zip . && cd ..
 
     - name: Upload Lambda email-digest
+      if: steps.changes.outputs.digest == 'true'
       run: |
         cd ./aws/lambda/email-digest/
         aws lambda update-function-code \
@@ -89,6 +142,7 @@ jobs:
 
 
     - name: Build Lambda email-unsub
+      if: steps.changes.outputs.unsub == 'true'
       run: |
         cd ./aws/lambda/email-unsub/
         rm -rf package lambda.zip
@@ -99,6 +153,7 @@ jobs:
         cd package && zip -r ../lambda.zip . && cd ..
 
     - name: Upload Lambda email-unsub
+      if: steps.changes.outputs.unsub == 'true'
       run: |
         cd ./aws/lambda/email-unsub/
         aws lambda update-function-code \
@@ -107,6 +162,7 @@ jobs:
 
 
     - name: Build Lambda aprs-to-discord
+      if: steps.changes.outputs.aprs == 'true'
       run: |
         cd ./aws/lambda/aprs-to-discord/
         rm -rf package lambda.zip
@@ -117,6 +173,7 @@ jobs:
         cd package && zip -r ../lambda.zip . && cd ..
 
     - name: Upload Lambda aprs-to-discord
+      if: steps.changes.outputs.aprs == 'true'
       run: |
         cd ./aws/lambda/aprs-to-discord/
         aws lambda update-function-code \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,180 +2,166 @@ name: Build/Deploy
 
 on:
   push:
-    branches: main
+    branches:
+      - main
+    paths:
+      - 'site/**'
+      - 'aws/lambda/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
 
 jobs:
-  build-and-deploy:
+  # Figure out what actually changed in this push and build a dynamic deploy
+  # matrix for the Lambdas (plus a flag for the static site). Manual dispatch
+  # (or a change to this workflow file itself) deploys everything; otherwise
+  # only the directories that were touched get deployed.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      any:    ${{ steps.build-matrix.outputs.any }}
+      site:   ${{ steps.build-matrix.outputs.site }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            workflow:
+              - '.github/workflows/deploy.yml'
+            site:
+              - 'site/**'
+            EVSRT-Reminder:
+              - 'aws/lambda/discord-reminder-bot/**'
+            EVSRT-HamAlert:
+              - 'aws/lambda/discord-spot-bot/**'
+            HamPals-Email-Digest:
+              - 'aws/lambda/email-digest/**'
+            HamPals-Email-Unsub:
+              - 'aws/lambda/email-unsub/**'
+            HamPals-APRS-Watch:
+              - 'aws/lambda/aprs-to-discord/**'
+
+      - id: build-matrix
+        env:
+          ALL_ENTRIES: |
+            [
+              {"function":"EVSRT-Reminder","path":"aws/lambda/discord-reminder-bot","python_version":"3.11"},
+              {"function":"EVSRT-HamAlert","path":"aws/lambda/discord-spot-bot","python_version":"3.11"},
+              {"function":"HamPals-Email-Digest","path":"aws/lambda/email-digest","python_version":"3.11"},
+              {"function":"HamPals-Email-Unsub","path":"aws/lambda/email-unsub","python_version":"3.11"},
+              {"function":"HamPals-APRS-Watch","path":"aws/lambda/aprs-to-discord","python_version":"3.11"}
+            ]
+          CHANGED: ${{ steps.filter.outputs.changes }}
+          SITE_CHANGED: ${{ steps.filter.outputs.site }}
+          WORKFLOW_CHANGED: ${{ steps.filter.outputs.workflow }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          python3 <<'PY'
+          import json, os
+          all_entries = json.loads(os.environ["ALL_ENTRIES"])
+          # dorny/paths-filter returns `changes` as a JSON array of group names that matched.
+          changed = set(json.loads(os.environ["CHANGED"]))
+          workflow_changed = os.environ["WORKFLOW_CHANGED"] == "true"
+          site_changed = os.environ["SITE_CHANGED"] == "true"
+          event = os.environ["EVENT_NAME"]
+
+          deploy_all = event == "workflow_dispatch" or workflow_changed
+          if deploy_all:
+              selected = all_entries
+              site = True
+              reason = "manual dispatch or workflow file changed -- deploying everything"
+          else:
+              selected = [e for e in all_entries if e["function"] in changed]
+              site = site_changed
+              reason = f"deploying lambdas={[e['function'] for e in selected]} site={site}"
+
+          out = json.dumps({"include": selected})
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"matrix={out}\n")
+              f.write(f"any={'true' if selected else 'false'}\n")
+              f.write(f"site={'true' if site else 'false'}\n")
+          print(reason)
+          PY
+
+  site:
+    needs: changes
+    if: needs.changes.outputs.site == 'true'
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        # Full history so we can diff this push against its predecessor.
-        fetch-depth: 0
+      - uses: actions/checkout@v4
 
-    - name: Detect changed paths
-      id: changes
-      run: |
-        BEFORE="${{ github.event.before }}"
-        ZERO="0000000000000000000000000000000000000000"
-        if [ -z "$BEFORE" ] || [ "$BEFORE" = "$ZERO" ] || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
-          # First push, force-push, or unknown base -> deploy everything.
-          echo "Base commit unavailable; deploying all targets."
-          CHANGED="__ALL__"
-        else
-          CHANGED="$(git diff --name-only "$BEFORE" "${{ github.sha }}")"
-        fi
-        echo "Changed files:"
-        echo "$CHANGED"
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
-        changed() {
-          [ "$CHANGED" = "__ALL__" ] && return 0
-          echo "$CHANGED" | grep -q "^$1"
-        }
+      - name: Deploy static content to S3
+        env:
+          AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+        run: |
+          GIT_BRANCH_SHORT=$(echo ${GITHUB_REF} | awk '{split($0,a,"/"); print a[3]}')
+          S3_DEST=${AWS_S3_BUCKET_NAME}/${GIT_BRANCH_SHORT}
 
-        site=false;     changed "site/"                            && site=true
-        reminder=false; changed "aws/lambda/discord-reminder-bot/" && reminder=true
-        spot=false;     changed "aws/lambda/discord-spot-bot/"     && spot=true
-        digest=false;   changed "aws/lambda/email-digest/"         && digest=true
-        unsub=false;    changed "aws/lambda/email-unsub/"          && unsub=true
-        aprs=false;     changed "aws/lambda/aprs-to-discord/"      && aprs=true
+          if [ "${GIT_BRANCH_SHORT}" == 'main' ]; then
+            S3_DEST=${AWS_S3_BUCKET_NAME}
+          fi
 
-        any_lambda=false
-        if [ "$reminder" = true ] || [ "$spot" = true ] || [ "$digest" = true ] || [ "$unsub" = true ] || [ "$aprs" = true ]; then
-          any_lambda=true
-        fi
+          aws s3 sync ./site/ s3://${S3_DEST}/ --region us-west-2 --cache-control max-age=120,must-revalidate --delete
 
-        {
-          echo "site=$site"
-          echo "reminder=$reminder"
-          echo "spot=$spot"
-          echo "digest=$digest"
-          echo "unsub=$unsub"
-          echo "aprs=$aprs"
-          echo "any_lambda=$any_lambda"
-        } >> "$GITHUB_OUTPUT"
+  deploy:
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # Consume the dynamic matrix produced by the `changes` job -- one deploy
+      # job per changed Lambda, each carrying its function name, source path,
+      # and Python version.
+      matrix: ${{ fromJson(needs.changes.outputs.matrix) }}
 
-    - name: Configure AWS CLI SDK
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+    steps:
+      - uses: actions/checkout@v4
 
-    - name: Deploy static content to S3
-      if: steps.changes.outputs.site == 'true'
-      env:
-        AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
-      run: |
-        GIT_BRANCH_SHORT=$(echo ${GITHUB_REF} | awk '{split($0,a,"/"); print a[3]}')
-        S3_DEST=${AWS_S3_BUCKET_NAME}/${GIT_BRANCH_SHORT}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python_version }}
 
-        if [ "${GIT_BRANCH_SHORT}" == 'main' ]; then
-          S3_DEST=${AWS_S3_BUCKET_NAME}
-        fi
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
-        aws s3 sync ./site/ s3://${S3_DEST}/ --region us-west-2 --cache-control max-age=120,must-revalidate --delete
+      - name: Install Python deps
+        working-directory: ${{ matrix.path }}
+        # Force linux x86_64 wheels for the matching Python version so the
+        # compiled artifacts match the Lambda runtime exactly.
+        # --only-binary=:all: refuses source builds that would otherwise
+        # produce host-arch artifacts.
+        run: |
+          pip install --quiet \
+            --platform manylinux2014_x86_64 \
+            --implementation cp \
+            --python-version ${{ matrix.python_version }} \
+            --only-binary=:all: \
+            --target . \
+            -r requirements.txt
 
-    - name: Set up Python
-      if: steps.changes.outputs.any_lambda == 'true'
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
+      - name: Zip
+        working-directory: ${{ matrix.path }}
+        run: zip -r -q "/tmp/${{ matrix.function }}.zip" .
 
-    - name: Build Lambda discord-reminder-bot
-      if: steps.changes.outputs.reminder == 'true'
-      run: |
-        cd ./aws/lambda/discord-reminder-bot/
-        python -m pip install --upgrade pip
-        mkdir -p package
-        pip install -r requirements.txt -t package/
-        cp lambda_function.py package/
-        cd package && zip -r ../lambda.zip . && cd ..
+      - name: Update Lambda code
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ matrix.function }} \
+            --zip-file fileb:///tmp/${{ matrix.function }}.zip \
+            --no-cli-pager
 
-    - name: Upload Lambda discord-reminder-bot
-      if: steps.changes.outputs.reminder == 'true'
-      run: |
-        cd ./aws/lambda/discord-reminder-bot/
-        aws lambda update-function-code \
-          --function-name EVSRT-Reminder \
-          --zip-file fileb://lambda.zip
-
-
-    - name: Build Lambda discord-spot-bot
-      if: steps.changes.outputs.spot == 'true'
-      run: |
-        cd ./aws/lambda/discord-spot-bot/
-        python -m pip install --upgrade pip
-        mkdir -p package
-        pip install -r requirements.txt -t package/
-        cp lambda_function.py package/
-        cd package && zip -r ../lambda.zip . && cd ..
-
-    - name: Upload Lambda discord-spot-bot
-      if: steps.changes.outputs.spot == 'true'
-      run: |
-        cd ./aws/lambda/discord-spot-bot/
-        aws lambda update-function-code \
-          --function-name EVSRT-HamAlert \
-          --zip-file fileb://lambda.zip
-
-
-    - name: Build Lambda email-digest
-      if: steps.changes.outputs.digest == 'true'
-      run: |
-        cd ./aws/lambda/email-digest/
-        rm -rf package lambda.zip
-        python -m pip install --upgrade pip
-        mkdir -p package
-        pip install -r requirements.txt -t package/
-        cp lambda_function.py package/
-        cd package && zip -r ../lambda.zip . && cd ..
-
-    - name: Upload Lambda email-digest
-      if: steps.changes.outputs.digest == 'true'
-      run: |
-        cd ./aws/lambda/email-digest/
-        aws lambda update-function-code \
-          --function-name HamPals-Email-Digest \
-          --zip-file fileb://lambda.zip
-
-
-    - name: Build Lambda email-unsub
-      if: steps.changes.outputs.unsub == 'true'
-      run: |
-        cd ./aws/lambda/email-unsub/
-        rm -rf package lambda.zip
-        python -m pip install --upgrade pip
-        mkdir -p package
-        pip install -r requirements.txt -t package/
-        cp lambda_function.py package/
-        cd package && zip -r ../lambda.zip . && cd ..
-
-    - name: Upload Lambda email-unsub
-      if: steps.changes.outputs.unsub == 'true'
-      run: |
-        cd ./aws/lambda/email-unsub/
-        aws lambda update-function-code \
-          --function-name HamPals-Email-Unsub \
-          --zip-file fileb://lambda.zip
-
-
-    - name: Build Lambda aprs-to-discord
-      if: steps.changes.outputs.aprs == 'true'
-      run: |
-        cd ./aws/lambda/aprs-to-discord/
-        rm -rf package lambda.zip
-        python -m pip install --upgrade pip
-        mkdir -p package
-        pip install -r requirements.txt -t package/
-        cp lambda_function.py callsigns.txt package/
-        cd package && zip -r ../lambda.zip . && cd ..
-
-    - name: Upload Lambda aprs-to-discord
-      if: steps.changes.outputs.aprs == 'true'
-      run: |
-        cd ./aws/lambda/aprs-to-discord/
-        aws lambda update-function-code \
-          --function-name HamPals-APRS-Watch \
-          --zip-file fileb://lambda.zip
+      - name: Wait for update to finish
+        run: aws lambda wait function-updated --function-name ${{ matrix.function }}

--- a/aws/lambda/aprs-to-discord/lambda_function.py
+++ b/aws/lambda/aprs-to-discord/lambda_function.py
@@ -163,10 +163,14 @@ def _format_message(active, now):
         comment = (entry.get("comment") or "").strip()
         if comment:
             lines.append(f"\U0001F4AC **Comment:** {comment}")
-        blocks.append("\n".join(lines))
+        # Prefix every line with "> " so Discord renders each station as a
+        # blockquote (left-border bar), keeping multiple stations in one
+        # message from running together.
+        blocks.append("\n".join(f"> {ln}" for ln in lines))
 
-    divider = "\n" + "─" * 12 + "\n"
-    message = "\U0001F4E1 **APRS Activity**\n\n" + divider.join(blocks)
+    # Blank line between quoted blocks so Discord draws a separate border
+    # bar per station rather than merging them into one quote.
+    message = "\U0001F4E1 **APRS Activity**\n\n" + "\n\n".join(blocks)
     # Discord hard-caps a message at 2000 chars.
     if len(message) > 1900:
         message = message[:1900].rstrip() + "\n… (truncated)"


### PR DESCRIPTION
## Summary
Two changes (PR #12):

### 1. Blockquote APRS station blocks
Same treatment as discord-spot-bot (#11): each station in an APRS message is now its own `> ` blockquote (left-border bar), blank-line separated, instead of the run-together unicode-divider list.

> 📡 **APRS Activity**
>
> 📻 **Callsign:** K3MGM-9
> 🕒 **Heard:** 2 min ago
> 📍 **Position:** 34.1, -118.4
> 📶 **Via:** DMR → K3MGM

### 2. Deploy only changed targets — matching angeles-intel
`deploy.yml` now mirrors the structure of `angeles-intel/.github/workflows/deploy-lambdas.yml`:
- a **`changes`** job using `dorny/paths-filter@v3` that builds a **dynamic deploy matrix** of just the changed Lambdas;
- a matrixed **`deploy`** job (one job per changed Lambda: setup-python, manylinux x86_64 dep install, zip, `update-function-code`, `wait function-updated`);
- a separate **`site`** job for the S3 sync, gated on `site/` changes;
- `on.push.paths` + `workflow_dispatch`; a change to the workflow file itself, or a manual dispatch, deploys **everything**.

evsrt specifics preserved: Lambda region **us-east-1**, site sync keeps `--region us-west-2`, Python 3.11. Lambda function names map to their dirs in the matrix (e.g. `HamPals-APRS-Watch` ← `aws/lambda/aprs-to-discord`).

Validated: YAML parses (jobs changes/site/deploy, gates confirmed); matrix-build logic unit-tested across aprs-only, aprs+site, site-only, workflow-changed, manual-dispatch, and nothing-relevant; aprs Lambda `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
