### PR TITLE
deploy.yml: fix email-digest dep install (sdist-only pin)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,18 +139,16 @@ jobs:
 
       - name: Install Python deps
         working-directory: ${{ matrix.path }}
-        # Force linux x86_64 wheels for the matching Python version so the
-        # compiled artifacts match the Lambda runtime exactly.
-        # --only-binary=:all: refuses source builds that would otherwise
-        # produce host-arch artifacts.
-        run: |
-          pip install --quiet \
-            --platform manylinux2014_x86_64 \
-            --implementation cp \
-            --python-version ${{ matrix.python_version }} \
-            --only-binary=:all: \
-            --target . \
-            -r requirements.txt
+        # The runner (ubuntu-latest x86_64 + setup-python above) already
+        # matches the Lambda runtime (Amazon Linux x86_64, same Python), so
+        # a plain target install produces Lambda-compatible artifacts -- pip
+        # picks the manylinux x86_64 wheels for compiled deps (cryptography,
+        # cffi) automatically. We deliberately do NOT use the
+        # --platform/--only-binary cross-build flags here: those require
+        # every pinned dep to ship a wheel, which starkbank-ecdsa==2.2.0
+        # (email-digest) does not -- it's a pure-Python sdist, and forcing
+        # binary-only broke the deploy.
+        run: pip install --quiet --target . -r requirements.txt
 
       - name: Zip
         working-directory: ${{ matrix.path }}


### PR DESCRIPTION
## The failure
On the post-merge run, every target deployed **except `email-digest`**, which failed at *Install Python deps*:
```
ERROR: Could not find a version that satisfies the requirement starkbank-ecdsa==2.2.0 (from versions: 2.3.0, 2.3.1)
ERROR: No matching distribution found for starkbank-ecdsa==2.2.0
```

## Cause
The matrix install (mirrored from angeles-intel) uses `--platform manylinux2014_x86_64 --only-binary=:all:`, which **requires every pinned dep to ship a wheel**. `email-digest` pins `starkbank-ecdsa==2.2.0`, which is **sdist-only** (wheels exist only for 2.3.0/2.3.1), so `--only-binary=:all:` rejected it. The other four Lambdas have all-wheel deps, so they deployed fine.

## Fix
Use a plain `pip install --target . -r requirements.txt`. The runner (ubuntu-latest x86_64 + `setup-python` 3.11) already matches the Lambda runtime, so pip still pulls the manylinux x86_64 wheels for compiled deps (cryptography, cffi) **and** can build the pure-Python sdist. The angeles `--platform`/`--only-binary` flags only matter when the build host differs from the target arch — not the case here. Keeps the entire changes/matrix/site structure intact; only the install command changed.

## Verified
- `starkbank-ecdsa==2.2.0` resolves with plain `pip download` (sdist), and **reproduces** the CI error under `--only-binary=:all:`.
- YAML parses (jobs: changes/site/deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
